### PR TITLE
Categorize transactions individually

### DIFF
--- a/packages/server/src/api/controllers/Cashflow/NewCashflowTransaction.ts
+++ b/packages/server/src/api/controllers/Cashflow/NewCashflowTransaction.ts
@@ -42,7 +42,7 @@ export default class NewCashflowTransactionController extends BaseController {
       this.validationResult,
       this.asyncMiddleware(this.newCashflowTransaction),
       this.catchServiceErrors
-    ); 
+    );
     router.post(
       '/transactions/uncategorize/bulk',
       [
@@ -113,6 +113,7 @@ export default class NewCashflowTransactionController extends BaseController {
       check('exchange_rate').optional().isFloat({ gt: 0 }).toFloat(),
       check('description').optional(),
       check('branch_id').optional({ nullable: true }).isNumeric().toInt(),
+      check('categorize_individually').optional().isBoolean().toBoolean(),
     ];
   }
 
@@ -154,7 +155,7 @@ export default class NewCashflowTransactionController extends BaseController {
     const { tenantId, userId } = req;
     const ownerContributionDTO = this.matchedBodyData(req);
 
-    
+
 
     try {
       const cashflowTransaction =
@@ -238,12 +239,15 @@ export default class NewCashflowTransactionController extends BaseController {
   ) => {
     const { tenantId } = req;
     const matchedObject = this.matchedBodyData(req);
+    const uncategorizedTransactionIds = matchedObject.uncategorizedTransactionIds;
+    const categorizeIndividually = matchedObject.categorize_individually ?? matchedObject.categorizeIndividually ?? false;
+
     const categorizeDTO = omit(matchedObject, [
       'uncategorizedTransactionIds',
+      'categorize_individually',
     ]) as ICategorizeCashflowTransactioDTO;
 
-    const uncategorizedTransactionIds =
-      matchedObject.uncategorizedTransactionIds;
+    categorizeDTO.categorizeIndividually = categorizeIndividually;
 
     try {
       await this.cashflowApplication.categorizeTransaction(

--- a/packages/server/src/api/controllers/Cashflow/NewCashflowTransaction.ts
+++ b/packages/server/src/api/controllers/Cashflow/NewCashflowTransaction.ts
@@ -42,7 +42,7 @@ export default class NewCashflowTransactionController extends BaseController {
       this.validationResult,
       this.asyncMiddleware(this.newCashflowTransaction),
       this.catchServiceErrors
-    );
+    ); 
     router.post(
       '/transactions/uncategorize/bulk',
       [
@@ -134,6 +134,7 @@ export default class NewCashflowTransactionController extends BaseController {
       check('credit_account_id').exists().isInt().toInt(),
 
       check('exchange_rate').optional().isFloat({ gt: 0 }).toFloat(),
+      check('tax_rate_id').optional({ nullable: true }).isNumeric().toInt(),
       check('branch_id').optional({ nullable: true }).isNumeric().toInt(),
       check('publish').default(false).isBoolean().toBoolean(),
     ];
@@ -152,6 +153,8 @@ export default class NewCashflowTransactionController extends BaseController {
   ) => {
     const { tenantId, userId } = req;
     const ownerContributionDTO = this.matchedBodyData(req);
+
+    
 
     try {
       const cashflowTransaction =

--- a/packages/server/src/interfaces/CashFlow.ts
+++ b/packages/server/src/interfaces/CashFlow.ts
@@ -245,6 +245,7 @@ export interface ICategorizeCashflowTransactioDTO {
   exchangeRate: number;
   description: string;
   branchId: number;
+  categorizeIndividually?: boolean;
 }
 
 export interface IUncategorizedCashflowTransaction {

--- a/packages/server/src/interfaces/CashFlow.ts
+++ b/packages/server/src/interfaces/CashFlow.ts
@@ -231,6 +231,7 @@ export interface ICashflowTransactionSchema {
   userId: number;
   publishedAt?: Date | null;
   branchId?: number;
+  tax_rate_id?: number | null;
 }
 
 export interface ICashflowTransactionInput extends ICashflowTransactionSchema {}

--- a/packages/server/src/interfaces/CashflowService.ts
+++ b/packages/server/src/interfaces/CashflowService.ts
@@ -52,6 +52,7 @@ export interface ICashflowCommandDTO {
 export interface ICashflowNewCommandDTO extends ICashflowCommandDTO {
   plaidAccountId?: string;
   uncategorizedTransactionId?: number;
+  taxRateId?: number;
 }
 
 export interface ICashflowTransaction {
@@ -86,6 +87,8 @@ export interface ICashflowTransaction {
   isCashCredit?: boolean;
 
   uncategorizedTransactionId?: number;
+
+  taxRateId?: number;
 }
 
 export interface ICashflowTransactionLine {

--- a/packages/server/src/services/Cashflow/NewCashflowTransactionService.ts
+++ b/packages/server/src/services/Cashflow/NewCashflowTransactionService.ts
@@ -76,18 +76,22 @@ export default class NewCashflowTransactionService {
   ): ICashflowTransactionInput => {
     const amount = newCashflowTransactionDTO.amount;
 
-    const fromDTO = pick(newCashflowTransactionDTO, [
-      'date',
-      'referenceNo',
-      'description',
-      'transactionType',
-      'exchangeRate',
-      'cashflowAccountId',
-      'creditAccountId',
-      'branchId',
-      'plaidTransactionId',
-      'uncategorizedTransactionId',
-    ]);
+    const fromDTO = {
+      ...pick(newCashflowTransactionDTO, [
+        'date',
+        'referenceNo',
+        'description',
+        'transactionType',
+        'exchangeRate',
+        'cashflowAccountId',
+        'creditAccountId',
+        'branchId',
+        'plaidTransactionId',
+        'uncategorizedTransactionId',
+      ]),
+      tax_rate_id: newCashflowTransactionDTO.taxRateId, 
+    };
+
     // Retreive the next invoice number.
     const autoNextNumber =
       this.autoIncrement.getNextTransactionNumber(tenantId);
@@ -108,8 +112,8 @@ export default class NewCashflowTransactionService {
       userId,
       ...(newCashflowTransactionDTO.publish
         ? {
-            publishedAt: new Date(),
-          }
+          publishedAt: new Date(),
+        }
         : {}),
     };
     return R.compose(
@@ -129,6 +133,7 @@ export default class NewCashflowTransactionService {
     userId?: number
   ): Promise<ICashflowTransaction> => {
     const { CashflowTransaction, Account } = this.tenancy.models(tenantId);
+
 
     // Retrieves the cashflow account or throw not found error.
     const cashflowAccount = await Account.query()

--- a/packages/server/src/services/Cashflow/utils.ts
+++ b/packages/server/src/services/Cashflow/utils.ts
@@ -73,6 +73,25 @@ export const transformCategorizeTransToCashflow = (
     publish: true,
   };
 };
+export const transformCategorizeSingleTransToCashflow = (
+  uncategorizeTransaction: IUncategorizedCashflowTransaction,
+  categorizeDTO: ICategorizeCashflowTransactioDTO
+): ICashflowNewCommandDTO => {
+  return {
+    date: categorizeDTO.date,
+    amount: uncategorizeTransaction.amount,
+    referenceNo: categorizeDTO.referenceNo,
+    description: categorizeDTO.description,
+    cashflowAccountId: uncategorizeTransaction.accountId,
+    creditAccountId: categorizeDTO.creditAccountId,
+    exchangeRate: categorizeDTO.exchangeRate || 1,
+    currencyCode: uncategorizeTransaction.currencyCode,
+    transactionNumber: categorizeDTO.transactionNumber,
+    transactionType: categorizeDTO.transactionType,
+    branchId: categorizeDTO?.branchId,
+    publish: true,
+  };
+};
 
 export const validateUncategorizedTransactionsNotExcluded = (
   transactions: Array<UncategorizeCashflowTransaction>

--- a/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
+++ b/packages/webapp/src/containers/CashFlow/AccountTransactions/AccountTransactionsActionsBar.tsx
@@ -49,6 +49,9 @@ import { withBankingActions } from '../withBankingActions';
 import { withBanking } from '../withBanking';
 import withAlertActions from '@/containers/Alert/withAlertActions';
 import { DialogsName } from '@/constants/dialogs';
+import { useSetTransactionsToCategorizeSelected } from '@/hooks/state/banking';
+import { useDispatch } from 'react-redux';
+import { enableMultipleCategorization, setUncategorizedTransactionIdForMatching, setCategorizeIndividually } from '@/store/banking/banking.reducer';
 
 function AccountTransactionsActionsBar({
   // #withDialogActions
@@ -87,6 +90,10 @@ function AccountTransactionsActionsBar({
   const isFeedsActive = !!currentAccount.is_feeds_active;
   const isFeedsPaused = currentAccount.is_feeds_paused;
   const isSyncingOwner = currentAccount.is_syncing_owner;
+
+  // Retrieves the plaid token.
+  const dispatch = useDispatch();
+  const setTransactionsToCategorizeSelected = useSetTransactionsToCategorizeSelected();
 
   // Handle table row size change.
   const handleTableRowSizeChange = (size) => {
@@ -173,6 +180,15 @@ function AccountTransactionsActionsBar({
       });
   };
 
+  const handleCategorizeBulkClick = () => {
+    if (!isEmpty(uncategorizedTransationsIdsSelected)) {
+      setTransactionsToCategorizeSelected(uncategorizedTransationsIdsSelected);
+      dispatch(enableMultipleCategorization({ enable: true }));
+      dispatch(setCategorizeIndividually({ enable: true }));
+      dispatch(setUncategorizedTransactionIdForMatching(uncategorizedTransationsIdsSelected[0]));
+    }
+  };
+
   // Handles the unexclude categorized button click.
   const handleUnexcludeUncategorizedBtnClick = () => {
     unexcludeUncategorizedTransactions({
@@ -194,7 +210,9 @@ function AccountTransactionsActionsBar({
 
   // Handle multi select transactions for categorization or matching.
   const handleMultipleCategorizingSwitch = (event) => {
-    enableMultipleCategorization(event.currentTarget.checked);
+    const enable = event.currentTarget.checked;
+    dispatch(enableMultipleCategorization({ enable }));
+      dispatch(setCategorizeIndividually({ enable: false }));
   };
   // Handle resume bank feeds syncing.
   const handleResumeFeedsSyncing = () => {
@@ -290,6 +308,15 @@ function AccountTransactionsActionsBar({
           </Tooltip>
         </If>
 
+        {!isEmpty(uncategorizedTransationsIdsSelected) && (
+          <Button
+            icon={<Icon icon="primary" iconSize={16} />}
+            text={'Categorize bulk'}
+            onClick={handleCategorizeBulkClick}
+            className={Classes.MINIMAL}
+            intent={Intent.Primary}
+          />
+        )}
         {!isEmpty(uncategorizedTransationsIdsSelected) && (
           <Button
             icon={<Icon icon="disable" iconSize={16} />}

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionContent.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionContent.tsx
@@ -7,13 +7,14 @@ import { withBanking } from '@/containers/CashFlow/withBanking';
 
 function CategorizeTransactionContentRoot({
   transactionsToCategorizeIdsSelected,
+  onlyCategorize, 
 }) {
   return (
     <CategorizeTransactionBoot
       uncategorizedTransactionsIds={transactionsToCategorizeIdsSelected}
     >
       <CategorizeTransactionDrawerBody>
-        <CategorizeTransactionForm />
+        <CategorizeTransactionForm onlyCategorize={onlyCategorize} /> 
       </CategorizeTransactionDrawerBody>
     </CategorizeTransactionBoot>
   );
@@ -22,7 +23,7 @@ function CategorizeTransactionContentRoot({
 export const CategorizeTransactionContent = R.compose(
   withBanking(({ transactionsToCategorizeIdsSelected }) => ({
     transactionsToCategorizeIdsSelected,
-  })),
+  }))
 )(CategorizeTransactionContentRoot);
 
 const CategorizeTransactionDrawerBody = styled.div`

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionForm.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionForm.tsx
@@ -14,6 +14,9 @@ import { withBankingActions } from '@/containers/CashFlow/withBankingActions';
 import { AppToaster } from '@/components';
 import { useCategorizeTransactionTabsBoot } from '@/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionTabsBoot';
 import { compose } from '@/utils';
+import { useSelector } from 'react-redux';
+import { getCategorizeIndividually } from '@/store/banking/banking.reducer';
+
 
 /**
  * Categorize cashflow transaction form dialog content.
@@ -24,14 +27,14 @@ function CategorizeTransactionFormRoot({
 }) {
   const { uncategorizedTransactionIds } = useCategorizeTransactionTabsBoot();
   const { mutateAsync: categorizeTransaction } = useCategorizeTransaction();
+  const categorizeIndividually = useSelector(getCategorizeIndividually);
 
   // Form initial values in create and edit mode.
   const initialValues = useCategorizeTransactionFormInitialValues();
 
   // Callbacks handles form submit.
   const handleFormSubmit = (values, { setSubmitting, setErrors }) => {
-    const _values = tranformToRequest(values, uncategorizedTransactionIds);
-
+    const _values = tranformToRequest(values, uncategorizedTransactionIds, categorizeIndividually);
     setSubmitting(true);
     categorizeTransaction(_values)
       .then(() => {

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionFormContent.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionFormContent.tsx
@@ -7,6 +7,8 @@ import { getAddMoneyInOptions, getAddMoneyOutOptions } from '@/constants';
 import { useFormikContext } from 'formik';
 import { useCategorizeTransactionTabsBoot } from '@/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionTabsBoot';
 import { useCategorizeTransactionBoot } from './CategorizeTransactionBoot';
+import { useSelector } from 'react-redux';
+import { getCategorizeIndividually } from '@/store/banking/banking.reducer';
 
 // Retrieves the add money in button options.
 const MoneyInOptions = getAddMoneyInOptions();
@@ -20,6 +22,7 @@ const Title = styled('h3')`
 
 export function CategorizeTransactionFormContent() {
   const { autofillCategorizeValues } = useCategorizeTransactionBoot();
+  const categorizeIndividually = useSelector(getCategorizeIndividually);
 
   const transactionTypes = autofillCategorizeValues?.isDepositTransaction
     ? MoneyInOptions
@@ -29,9 +32,11 @@ export function CategorizeTransactionFormContent() {
 
   return (
     <Box style={{ flex: 1, margin: 20 }}>
-      <FormGroup label={'Amount'} inline>
-        <Title>{formattedAmount}</Title>
-      </FormGroup>
+      {!categorizeIndividually && (
+        <FormGroup label={'Amount'} inline>
+          <Title>{formattedAmount}</Title>
+        </FormGroup>
+      )}
 
       <FFormGroup name={'category'} label={'Category'} fastField inline>
         <FSelect
@@ -75,25 +80,21 @@ const CategorizeTransactionOwnerDrawings = React.lazy(
 
 function CategorizeTransactionFormSubContent() {
   const { values } = useFormikContext();
+  const categorizeIndividually = useSelector(getCategorizeIndividually);
 
-  // Other expense.
+  
   if (values.transactionType === 'other_expense') {
-    return <CategorizeTransactionOtherExpense />;
-    // Owner contribution.
+    return <CategorizeTransactionOtherExpense categorizeIndividually={categorizeIndividually} />;
   } else if (values.transactionType === 'owner_contribution') {
-    return <CategorizeTransactionOwnerContribution />;
-    // Other Income.
+    return <CategorizeTransactionOwnerContribution categorizeIndividually={categorizeIndividually} />;
   } else if (values.transactionType === 'other_income') {
-    return <CategorizeTransactionOtherIncome />;
-    // Transfer from account.
+    return <CategorizeTransactionOtherIncome categorizeIndividually={categorizeIndividually} />;
   } else if (values.transactionType === 'transfer_from_account') {
-    return <CategorizeTransactionTransferFrom />;
-    // Transfer to account.
+    return <CategorizeTransactionTransferFrom categorizeIndividually={categorizeIndividually} />;
   } else if (values.transactionType === 'transfer_to_account') {
-    return <CategorizeTransactionToAccount />;
-    // Owner drawings.
+    return <CategorizeTransactionToAccount categorizeIndividually={categorizeIndividually} />;
   } else if (values.transactionType === 'OwnerDrawing') {
-    return <CategorizeTransactionOwnerDrawings />;
+    return <CategorizeTransactionOwnerDrawings categorizeIndividually={categorizeIndividually} />;
   }
   return null;
 }

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOtherIncome.tsx
@@ -11,7 +11,8 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionOtherIncome() {
+
+export default function CategorizeTransactionOtherIncome({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,6 +63,7 @@ export default function CategorizeTransactionOtherIncome() {
         <FInputGroup name={'referenceNo'} fill />
       </FFormGroup>
 
+      {!categorizeIndividually && (
       <FFormGroup name={'description'} label={'Description'} fastField inline>
         <FTextArea
           name={'description'}
@@ -70,6 +72,7 @@ export default function CategorizeTransactionOtherIncome() {
           fill={true}
         />
       </FFormGroup>
+      )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionOwnerContribution.tsx
@@ -11,7 +11,7 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionOwnerContribution() {
+export default function CategorizeTransactionOwnerContribution({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,9 +62,11 @@ export default function CategorizeTransactionOwnerContribution() {
         <FInputGroup name={'reference_no'} fill />
       </FFormGroup>
 
-      <FFormGroup name={'description'} label={'Description'} fastField inline>
-        <FTextArea name={'description'} growVertically large fill />
-      </FFormGroup>
+      {!categorizeIndividually && (
+        <FFormGroup name={'description'} label={'Description'} fastField inline>
+          <FTextArea name={'description'} growVertically large fill />
+        </FFormGroup>
+      )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyIn/CategorizeTransactionTransferFrom.tsx
@@ -11,7 +11,7 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionTransferFrom() {
+export default function CategorizeTransactionTransferFrom({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,6 +62,7 @@ export default function CategorizeTransactionTransferFrom() {
         <FInputGroup name={'reference_no'} fill />
       </FFormGroup>
 
+     {!categorizeIndividually && (
       <FFormGroup name={'description'} label={'Description'} fastField inline>
         <FTextArea
           name={'description'}
@@ -70,6 +71,7 @@ export default function CategorizeTransactionTransferFrom() {
           fill={true}
         />
       </FFormGroup>
+     )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOtherExpense.tsx
@@ -11,7 +11,7 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionOtherExpense() {
+export default function CategorizeTransactionOtherExpense({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,6 +62,7 @@ export default function CategorizeTransactionOtherExpense() {
         <FInputGroup name={'reference_no'} fill />
       </FFormGroup>
 
+      {!categorizeIndividually && (
       <FFormGroup name={'description'} label={'Description'} fastField inline>
         <FTextArea
           name={'description'}
@@ -70,6 +71,7 @@ export default function CategorizeTransactionOtherExpense() {
           fill={true}
         />
       </FFormGroup>
+      )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionOwnerDrawings.tsx
@@ -11,7 +11,7 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionOwnerDrawings() {
+export default function CategorizeTransactionOwnerDrawings({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,14 +62,16 @@ export default function CategorizeTransactionOwnerDrawings() {
         <FInputGroup name={'reference_no'} fill />
       </FFormGroup>
 
-      <FFormGroup name={'description'} label={'Description'} fastField inline>
-        <FTextArea
-          name={'description'}
-          growVertically={true}
-          large={true}
-          fill={true}
-        />
-      </FFormGroup>
+      {!categorizeIndividually && (
+        <FFormGroup name={'description'} label={'Description'} fastField inline>
+          <FTextArea
+            name={'description'}
+            growVertically={true}
+            large={true}
+            fill={true}
+          />
+        </FFormGroup>
+      )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/MoneyOut/CategorizeTransactionToAccount.tsx
@@ -11,7 +11,7 @@ import {
 import { useCategorizeTransactionBoot } from '../CategorizeTransactionBoot';
 import { CategorizeTransactionBranchField } from '../CategorizeTransactionBranchField';
 
-export default function CategorizeTransactionToAccount() {
+export default function CategorizeTransactionToAccount({ categorizeIndividually }) {
   const { accounts } = useCategorizeTransactionBoot();
 
   return (
@@ -62,14 +62,16 @@ export default function CategorizeTransactionToAccount() {
         <FInputGroup name={'reference_no'} fill />
       </FFormGroup>
 
-      <FFormGroup name={'description'} label={'Description'} fastField inline>
-        <FTextArea
-          name={'description'}
-          growVertically={true}
-          large={true}
-          fill={true}
-        />
-      </FFormGroup>
+      {!categorizeIndividually && (
+        <FFormGroup name={'description'} label={'Description'} fastField inline>
+          <FTextArea
+            name={'description'}
+            growVertically={true}
+            large={true}
+            fill={true}
+          />
+        </FFormGroup>
+      )}
 
       <CategorizeTransactionBranchField />
     </>

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/_utils.ts
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransaction/drawers/CategorizeTransactionDrawer/_utils.ts
@@ -26,8 +26,10 @@ export const transformToCategorizeForm = (
 export const tranformToRequest = (
   formValues: Record<string, any>,
   uncategorizedTransactionIds: Array<number>,
+  categorizeIndividually: boolean,
 ) => {
   return {
+    categorize_individually: categorizeIndividually,
     uncategorized_transaction_ids: uncategorizedTransactionIds,
     ...transfromToSnakeCase(formValues),
   };

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionAside.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionAside.tsx
@@ -9,8 +9,10 @@ import {
 import { CategorizeTransactionTabsBoot } from './CategorizeTransactionTabsBoot';
 import { withBanking } from '../withBanking';
 import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { setCategorizeIndividually } from '@/store/banking/banking.reducer';
 
-interface CategorizeTransactionAsideProps extends WithBankingActionsProps {}
+interface CategorizeTransactionAsideProps extends WithBankingActionsProps { }
 
 function CategorizeTransactionAsideRoot({
   // #withBankingActions
@@ -22,6 +24,7 @@ function CategorizeTransactionAsideRoot({
   resetTransactionsToCategorizeSelected,
   enableMultipleCategorization,
 }: CategorizeTransactionAsideProps) {
+  const dispatch = useDispatch();
   //
   useEffect(
     () => () => {
@@ -33,6 +36,8 @@ function CategorizeTransactionAsideRoot({
 
       // Disable multi matching.
       enableMultipleCategorization(false);
+
+      dispatch(setCategorizeIndividually({ enable: false }));
     },
     [
       closeReconcileMatchingTransaction,

--- a/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionTabs.tsx
+++ b/packages/webapp/src/containers/CashFlow/CategorizeTransactionAside/CategorizeTransactionTabs.tsx
@@ -1,11 +1,19 @@
 // @ts-nocheck
 import { Tab, Tabs } from '@blueprintjs/core';
+import { useSelector } from 'react-redux';
+import { getCategorizeIndividually } from '@/store/banking/banking.reducer';
 import { MatchingBankTransaction } from './MatchingTransaction';
 import { CategorizeTransactionContent } from '../CategorizeTransaction/drawers/CategorizeTransactionDrawer/CategorizeTransactionContent';
 import styles from './CategorizeTransactionTabs.module.scss';
 
 export function CategorizeTransactionTabs() {
   const defaultSelectedTabId = 'categorize';
+
+  const categorizeIndividually = useSelector(getCategorizeIndividually);
+
+  if (categorizeIndividually) {
+    return <CategorizeTransactionContent onlyCategorize />;
+  }
 
   return (
     <Tabs

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInFieldsProvider.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInFieldsProvider.tsx
@@ -6,7 +6,7 @@ import { useMoneyInDailogContext } from './MoneyInDialogProvider';
 import { useTaxRates } from '@/hooks/query/taxRates';
 
 const MoneyInFieldsContext = React.createContext();
-
+  
 /**
  * Money in dialog provider.
  */

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInForm.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/MoneyInForm.tsx
@@ -78,6 +78,7 @@ function MoneyInForm({
       ...omit(values, ['currency_code']),
       publish: true,
     };
+    console.log('Form Data:', form);
     setSubmitting(true);
     createCashflowTransactionMutate(form)
       .then(() => {

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
@@ -12,6 +12,7 @@ import {
   Col,
   Row,
   BranchSelect,
+  TaxRatesSelect,
   BranchSelectButton,
   FeatureCan,
   FFormGroup,
@@ -41,7 +42,7 @@ import { MoneyInExchangeRateField } from '../MoneyInExchangeRateField';
  */
 export default function OwnerContributionFormFields() {
   // Money in dialog context.
-  const { accounts, branches } = useMoneyInDailogContext();
+  const { accounts, branches, taxRates } = useMoneyInDailogContext();
   const { account } = useMoneyInFieldsContext();
 
   // Sets the primary branch to form.
@@ -102,7 +103,7 @@ export default function OwnerContributionFormFields() {
 
       {/*------------ Amount -----------*/}
       <Row>
-        <Col xs={10}>
+        <Col xs={5}>
           <FFormGroup
             name={'amount'}
             label={<T id={'amount'} />}
@@ -112,6 +113,19 @@ export default function OwnerContributionFormFields() {
               <InputPrependText text={account?.currency_code || '--'} />
               <FMoneyInputGroup name={'amount'} minimal={true} />
             </ControlGroup>
+          </FFormGroup>
+        </Col>
+
+        <Col xs={5}>
+          <FFormGroup
+            name={'tax_rate_id'}
+            label={'Tax Rate'}
+          >
+            <TaxRatesSelect
+              name={'tax_rate_id'}
+              items={taxRates}
+              allowCreate
+            />
           </FFormGroup>
         </Col>
       </Row>

--- a/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
+++ b/packages/webapp/src/containers/CashFlow/MoneyInDialog/OwnerContribution/OwnerContributionFormFields.tsx
@@ -121,6 +121,7 @@ export default function OwnerContributionFormFields() {
             name={'tax_rate_id'}
             label={'Tax Rate'}
           >
+            
             <TaxRatesSelect
               name={'tax_rate_id'}
               items={taxRates}

--- a/packages/webapp/src/store/banking/banking.reducer.ts
+++ b/packages/webapp/src/store/banking/banking.reducer.ts
@@ -13,6 +13,8 @@ interface StorePlaidState {
 
   enableMultipleCategorization: boolean;
 
+  categorizeIndividually: boolean;
+
   categorizedTransactionsSelected: Array<number | string>;
 }
 
@@ -30,6 +32,7 @@ export const PlaidSlice = createSlice({
     excludedTransactionsSelected: [],
     transactionsToCategorizeSelected: [],
     enableMultipleCategorization: false,
+    categorizeIndividually: false,
     categorizedTransactionsSelected: [],
   } as StorePlaidState,
   reducers: {
@@ -77,6 +80,18 @@ export const PlaidSlice = createSlice({
       action: PayloadAction<{ transactionIds: Array<string | number> }>,
     ) => {
       state.uncategorizedTransactionsSelected = action.payload.transactionIds;
+    },
+
+    /**
+     * Enables/Disables the categorize individually.
+     * @param {StorePlaidState} state
+     * @param {PayloadAction<{ enable: boolean }>} action
+     */
+    setCategorizeIndividually: (
+      state: StorePlaidState,
+      action: PayloadAction<{ enable: boolean }>,
+    ) => {
+      state.categorizeIndividually = action.payload.enable;
     },
 
     /**
@@ -220,6 +235,7 @@ export const {
   enableMultipleCategorization,
   setCategorizedTransactionsSelected,
   resetCategorizedTransactionsSelected,
+  setCategorizeIndividually,
 } = PlaidSlice.actions;
 
 export const getPlaidToken = (state: any) => state.plaid.plaidToken;
@@ -234,3 +250,6 @@ export const isMultipleCategorization = (state: any) =>
 
 export const getTransactionsToCategorizeIdsSelected = (state: any) =>
   state.plaid.transactionsToCategorizeSelected;
+
+export const getCategorizeIndividually = (state: any) =>
+  state.plaid.categorizeIndividually;


### PR DESCRIPTION
### Summary
- Added `categorizeIndividually` toggle to support categorizing multiple transactions as separate entries.
- Updated backend DTO, controller, and service to respect this flag.
- Adjusted CategorizeTransaction UI to dynamically hide description field when `categorizeIndividually` is true.
- Disabled "Multi Select" toggle when "Categorize Bulk" is triggered.

### Changes
- Backend: controller, service, utils
- Frontend: CategorizeTransactionDrawer, Aside, FormContent, Switch logic
- Redux: `enableMultipleCategorization`, `setCategorizeIndividually` reducers

